### PR TITLE
feat: Implement audit logging for manual hour additions

### DIFF
--- a/src/commands/assignRoles.ts
+++ b/src/commands/assignRoles.ts
@@ -23,28 +23,65 @@ export default {
         .setDescription('The ID of the channel containing the message')
         .setRequired(true)
     )
+    // Support 1–10 roles (role_1 required; role_2..role_10 optional)
     .addRoleOption(option =>
       option
         .setName('role_1')
-        .setDescription('First faction role to assign')
+        .setDescription('Faction role to assign (required)')
         .setRequired(true)
     )
     .addRoleOption(option =>
       option
         .setName('role_2')
-        .setDescription('Second faction role to assign')
-        .setRequired(true)
+        .setDescription('Faction role to assign')
+        .setRequired(false)
     )
     .addRoleOption(option =>
       option
         .setName('role_3')
-        .setDescription('Third faction role to assign')
+        .setDescription('Faction role to assign')
         .setRequired(false)
     )
     .addRoleOption(option =>
       option
         .setName('role_4')
-        .setDescription('Fourth faction role to assign')
+        .setDescription('Faction role to assign')
+        .setRequired(false)
+    )
+    .addRoleOption(option =>
+      option
+        .setName('role_5')
+        .setDescription('Faction role to assign')
+        .setRequired(false)
+    )
+    .addRoleOption(option =>
+      option
+        .setName('role_6')
+        .setDescription('Faction role to assign')
+        .setRequired(false)
+    )
+    .addRoleOption(option =>
+      option
+        .setName('role_7')
+        .setDescription('Faction role to assign')
+        .setRequired(false)
+    )
+    .addRoleOption(option =>
+      option
+        .setName('role_8')
+        .setDescription('Faction role to assign')
+        .setRequired(false)
+    )
+    .addRoleOption(option =>
+      option
+        .setName('role_9')
+        .setDescription('Faction role to assign')
+        .setRequired(false)
+    )
+    .addRoleOption(option =>
+      option
+        .setName('role_10')
+        .setDescription('Faction role to assign')
         .setRequired(false)
     ),
 
@@ -82,17 +119,31 @@ export default {
       const messageId = interaction.options.getString('message_id', true);
       const channelId = interaction.options.getString('channel_id', true);
 
+      const roleOptionNames = [
+        'role_1',
+        'role_2',
+        'role_3',
+        'role_4',
+        'role_5',
+        'role_6',
+        'role_7',
+        'role_8',
+        'role_9',
+        'role_10',
+      ];
+
       const roles: Role[] = [];
-      for (const optionName of ['role_1', 'role_2', 'role_3', 'role_4']) {
-        const role = interaction.options.getRole(optionName as any, optionName === 'role_1' || optionName === 'role_2') as Role | null;
+      for (const optionName of roleOptionNames) {
+        const required = optionName === 'role_1';
+        const role = interaction.options.getRole(optionName as any, required) as Role | null;
         if (role) {
           roles.push(role);
         }
       }
 
-      if (roles.length < 2) {
+      if (roles.length < 1) {
         await interaction.editReply({
-          content: '❌ Please provide at least two roles for balanced assignment.',
+          content: '❌ Please provide at least one role.',
         });
         return;
       }

--- a/src/commands/eventFaction.ts
+++ b/src/commands/eventFaction.ts
@@ -41,6 +41,17 @@ export default {
             .setDescription('Name of the new system faction')
             .setRequired(true)
         )
+    )
+    .addSubcommand(subcommand =>
+      subcommand
+        .setName('disband-faction')
+        .setDescription('Disband an event/system faction (Admin only)')
+        .addRoleOption(option =>
+          option
+            .setName('faction_role')
+            .setDescription('Faction role representing the faction to disband')
+            .setRequired(true)
+        )
     ),
 
   async execute(interaction: ChatInputCommandInteraction) {
@@ -56,11 +67,11 @@ export default {
 
       const subcommand = interaction.options.getSubcommand();
 
-      if (subcommand === 'create-faction') {
+      if (subcommand === 'create-faction' || subcommand === 'disband-faction') {
         // Strictly admin-only per requirements
         if (!interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)) {
           await interaction.reply({
-            content: '❌ You need Administrator permission to create system factions.',
+            content: '❌ You need Administrator permission to use this command.',
             ephemeral: true,
           });
           return;
@@ -94,6 +105,9 @@ export default {
           break;
         case 'create-faction':
           await handleCreateSystemFaction(interaction, guildId);
+          break;
+        case 'disband-faction':
+          await handleDisbandFaction(interaction, guildId);
           break;
         default:
           await interaction.editReply({
@@ -259,7 +273,7 @@ async function handleCreateSystemFaction(
     return;
   }
 
-  const systemOwnerId = interaction.user.id;
+  const systemOwnerId = 'EVENTFACTION';
   const initialDeposit = 0;
 
   const creationResult = await factionManager.createFaction(
@@ -285,6 +299,12 @@ async function handleCreateSystemFaction(
       $set: {
         isSystemFaction: true,
         createdBy: interaction.user.id,
+        ownerId: systemOwnerId,
+        officers: [],
+        members: [],
+        totalMembersEver: 0,
+        peakMemberCount: 0,
+        membersWhoGaveXp: [],
       },
     }
   );
@@ -302,3 +322,66 @@ async function handleCreateSystemFaction(
   );
 }
 
+async function handleDisbandFaction(
+  interaction: ChatInputCommandInteraction,
+  guildId: string
+): Promise<void> {
+  const factionRole = interaction.options.getRole('faction_role', true);
+
+  if (!interaction.guild) {
+    await interaction.editReply({
+      content: '❌ This command can only be used in a server.',
+    });
+    return;
+  }
+
+  const faction = await database.factions.findOne({
+    guildId,
+    roleId: factionRole.id,
+    disbanded: { $ne: true },
+  });
+
+  if (!faction) {
+    await interaction.editReply({
+      content: '❌ No active faction is linked to that role.',
+    });
+    return;
+  }
+
+  // Mark faction as disbanded
+  await database.factions.updateOne(
+    { id: faction.id, guildId },
+    {
+      $set: {
+        disbanded: true,
+        disbandedAt: new Date(),
+        disbandedReason: 'manual',
+        updatedAt: new Date(),
+      },
+    }
+  );
+
+  // Clear currentFaction for users in this faction
+  await database.users.updateMany(
+    { guildId, currentFaction: faction.id },
+    {
+      $set: {
+        currentFaction: null,
+        updatedAt: new Date(),
+      },
+    }
+  );
+
+  // Attempt to remove Discord resources
+  try {
+    await discordResourceManager.deleteFactionResources(interaction.guild, faction.roleId, faction.channelId);
+  } catch (error) {
+    logger.warn(`Failed to delete resources for faction ${faction.id}:`, error);
+  }
+
+  await interaction.editReply({
+    content: `✅ Faction **${faction.name}** has been disbanded and its members unlinked.`,
+  });
+
+  logger.info(`Faction ${faction.id} disbanded by ${interaction.user.id} in guild ${guildId}`);
+}

--- a/src/commands/reactionroleRemove.ts
+++ b/src/commands/reactionroleRemove.ts
@@ -33,16 +33,24 @@ export default {
 
   async execute(interaction: ChatInputCommandInteraction) {
     try {
+      if (!interaction.guildId || !interaction.guild) {
+        await interaction.reply({
+          content: '❌ This command can only be used in a server.',
+          ephemeral: true,
+        });
+        return;
+      }
+
       await interaction.deferReply({ ephemeral: true });
 
-      const guildId = interaction.guildId!;
+      const guildId = interaction.guildId;
       const messageId = interaction.options.getString('messageid', true);
       const channelId = interaction.options.getString('channelid') || interaction.channelId;
       const emojiInput = interaction.options.getString('emoji') || '✅';
 
       // Permission: admin or staff role
       const config = configManager.getConfig(guildId);
-      const member = interaction.guild?.members.cache.get(interaction.user.id);
+      const member = await interaction.guild.members.fetch(interaction.user.id).catch(() => null);
       if (!member) {
         await interaction.editReply({ content: '❌ Could not verify your permissions.' });
         return;

--- a/src/commands/reactionroleRemove.ts
+++ b/src/commands/reactionroleRemove.ts
@@ -1,0 +1,123 @@
+import {
+  SlashCommandBuilder,
+  ChatInputCommandInteraction,
+  PermissionFlagsBits,
+} from 'discord.js';
+import { database } from '../database/client';
+import { configManager } from '../core/configManager';
+import logger from '../core/logger';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('reactionrole-remove')
+    .setDescription('Remove a reaction role configuration and its reaction (Admin/staff)')
+    .addStringOption(option =>
+      option
+        .setName('messageid')
+        .setDescription('The ID of the message with the reaction role')
+        .setRequired(true)
+    )
+    .addStringOption(option =>
+      option
+        .setName('channelid')
+        .setDescription('The channel ID where the message is located (defaults to current channel)')
+        .setRequired(false)
+    )
+    .addStringOption(option =>
+      option
+        .setName('emoji')
+        .setDescription('Emoji to remove (default: ✅)')
+        .setRequired(false)
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.Administrator),
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    try {
+      await interaction.deferReply({ ephemeral: true });
+
+      const guildId = interaction.guildId!;
+      const messageId = interaction.options.getString('messageid', true);
+      const channelId = interaction.options.getString('channelid') || interaction.channelId;
+      const emojiInput = interaction.options.getString('emoji') || '✅';
+
+      // Permission: admin or staff role
+      const config = configManager.getConfig(guildId);
+      const member = interaction.guild?.members.cache.get(interaction.user.id);
+      if (!member) {
+        await interaction.editReply({ content: '❌ Could not verify your permissions.' });
+        return;
+      }
+      const hasPermission =
+        member.permissions.has(PermissionFlagsBits.Administrator) ||
+        (config.admin?.staffRoleIds?.some(roleId => member.roles.cache.has(roleId)) ?? false);
+      if (!hasPermission) {
+        await interaction.editReply({
+          content: '❌ You need administrator permissions or a staff role to use this command.',
+        });
+        return;
+      }
+
+      // Fetch channel & message
+      const channel = await interaction.client.channels.fetch(channelId).catch(() => null);
+      if (!channel || !channel.isTextBased()) {
+        await interaction.editReply({
+          content: '❌ Could not find that channel or it is not a text channel.',
+        });
+        return;
+      }
+
+      let message;
+      try {
+        message = await (channel as any).messages.fetch(messageId);
+      } catch (error) {
+        await interaction.editReply({
+          content: '❌ Could not find message with that ID in the specified channel.',
+        });
+        return;
+      }
+
+      // Remove DB entry
+      const deleteResult = await database.reactionRoles.deleteOne({
+        messageId,
+        emoji: emojiInput,
+        guildId,
+      });
+
+      // Remove reaction (best effort)
+      try {
+        const reaction =
+          message.reactions.resolve(emojiInput) ||
+          message.reactions.cache.find(
+            r => r.emoji.id === emojiInput || r.emoji.name === emojiInput
+          );
+        if (reaction) {
+          await reaction.remove();
+        }
+      } catch (error) {
+        logger.warn(`Failed to remove reaction ${emojiInput} on message ${messageId}:`, error);
+      }
+
+      const removed = deleteResult.deletedCount || 0;
+      await interaction.editReply({
+        content: `✅ Removal complete. DB entries removed: ${removed}. Reaction cleaned (best effort).`,
+      });
+
+      logger.info(
+        `Reaction role removal: message ${messageId}, emoji ${emojiInput}, guild ${guildId}, removed ${removed}`
+      );
+    } catch (error) {
+      logger.error('Error in reactionrole-remove command:', error);
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({
+          content: '❌ An error occurred while removing the reaction role.',
+        });
+      } else {
+        await interaction.reply({
+          content: '❌ An error occurred while removing the reaction role.',
+          ephemeral: true,
+        });
+      }
+    }
+  },
+};
+

--- a/src/commands/removeHours.ts
+++ b/src/commands/removeHours.ts
@@ -34,7 +34,15 @@ export default {
 
   async execute(interaction: ChatInputCommandInteraction) {
     try {
-      const guildId = interaction.guildId!;
+      const guildId = interaction.guildId;
+      if (!guildId) {
+        await interaction.reply({
+          content: '❌ This command can only be used in a server.',
+          ephemeral: true,
+        });
+        return;
+      }
+
       const member = interaction.member;
 
       if (!member || typeof (member as any).permissions === 'string') {

--- a/src/commands/removeHours.ts
+++ b/src/commands/removeHours.ts
@@ -10,25 +10,25 @@ import logger from '../core/logger';
 
 export default {
   data: new SlashCommandBuilder()
-    .setName('add-hours')
-    .setDescription('Manually add VC time to a user (Staff only)')
+    .setName('remove-hours')
+    .setDescription('Manually remove VC time from a user (Staff only)')
     .addUserOption(option =>
       option
         .setName('user')
-        .setDescription('The user to add VC time to')
+        .setDescription('The user to remove VC time from')
         .setRequired(true)
     )
     .addIntegerOption(option =>
       option
         .setName('minutes')
-        .setDescription('Amount of VC time to add (in minutes)')
+        .setDescription('Amount of VC time to remove (in minutes)')
         .setRequired(true)
         .setMinValue(1)
     )
     .addStringOption(option =>
       option
         .setName('date')
-        .setDescription('Date the time should be credited for (YYYY-MM-DD, UTC)')
+        .setDescription('Date the time should be deducted for (YYYY-MM-DD, UTC)')
         .setRequired(true)
     ),
 
@@ -60,7 +60,6 @@ export default {
       const minutes = interaction.options.getInteger('minutes', true);
       const dateInput = interaction.options.getString('date', true).trim();
 
-      // Basic date validation: expect YYYY-MM-DD
       const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
       if (!dateRegex.test(dateInput)) {
         await interaction.editReply({
@@ -77,7 +76,6 @@ export default {
         return;
       }
 
-      // Verify the date didn't roll over (e.g., Feb 30 → Mar 1)
       const [year, month, day] = dateInput.split('-').map(Number);
       if (
         creditedAt.getUTCFullYear() !== year ||
@@ -92,31 +90,30 @@ export default {
 
       const durationMs = minutes * 60 * 1000;
 
-      // Fetch user document
       const userDoc = await database.users.findOne({ id: targetUser.id, guildId });
       if (!userDoc) {
         await interaction.editReply({
-          content: '❌ User not found in the database. They must have used the bot at least once.',
+          content: '❌ User not found in the database.',
         });
         return;
       }
 
-      // Calculate coins using the same logic as VC tracking (with multipliers)
-      const coinsEarned = await coinCalculator.calculateCoins(durationMs, guildId, targetUser.id);
+      const coinsToRemove = await coinCalculator.calculateCoins(durationMs, guildId, targetUser.id);
 
-      // Update user aggregates
       const balanceBefore = userDoc.coins;
-      const balanceAfter = balanceBefore + coinsEarned;
+      const coinsDelta = Math.min(coinsToRemove, balanceBefore);
+      const balanceAfter = balanceBefore - coinsDelta;
+
+      const newTotalVcTime = Math.max(0, (userDoc.totalVcTime || 0) - durationMs);
+      const newTotalCoinsEarned = Math.max(0, (userDoc.totalCoinsEarned || 0) - coinsToRemove);
 
       const updateResult = await database.users.updateOne(
         { id: targetUser.id, guildId },
         {
-          $inc: {
-            totalVcTime: durationMs,
-            coins: coinsEarned,
-            totalCoinsEarned: coinsEarned,
-          },
           $set: {
+            totalVcTime: newTotalVcTime,
+            totalCoinsEarned: newTotalCoinsEarned,
+            coins: balanceAfter,
             updatedAt: new Date(),
           },
         }
@@ -129,22 +126,20 @@ export default {
         return;
       }
 
-      // Create transaction record
-      const transactionId = `tx_manual_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
-
+      const transactionId = `tx_manual_remove_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
       try {
         await database.transactions.insertOne({
           id: transactionId,
           userId: targetUser.id,
           type: 'vctime_earn',
-          amount: coinsEarned,
+          amount: -coinsDelta,
           balanceAfter,
           metadata: {
-            duration: durationMs,
+            durationRemoved: durationMs,
             channelId: null,
             factionId: null,
             guildId,
-            source: 'manual_add_hours',
+            source: 'manual_remove_hours',
             creditedAt,
             staffUserId: interaction.user.id,
           },
@@ -152,74 +147,52 @@ export default {
         });
       } catch (error) {
         logger.error(
-          `Failed to create manual vctime_earn transaction ${transactionId} for user ${targetUser.id}:`,
+          `Failed to create manual remove transaction ${transactionId} for user ${targetUser.id}:`,
           error
         );
-        // Do not fail the command if transaction logging fails
       }
 
       const embed = new EmbedBuilder()
-        .setColor(0x3498db)
-        .setTitle('✅ VC Time Manually Added')
-        .setDescription(`Added **${minutes}** minutes of VC time to ${targetUser}`)
+        .setColor(0xe67e22)
+        .setTitle('✅ VC Time Manually Removed')
+        .setDescription(`Removed **${minutes}** minutes of VC time from ${targetUser}`)
         .addFields(
-          {
-            name: '🕒 Duration',
-            value: `${minutes} minutes`,
-            inline: true,
-          },
-          {
-            name: '📅 Credited Date (UTC)',
-            value: dateInput,
-            inline: true,
-          },
-          {
-            name: '💰 Coins Earned',
-            value: coinsEarned.toLocaleString(),
-            inline: true,
-          },
-          {
-            name: '💵 Balance Before',
-            value: `${balanceBefore.toLocaleString()} coins`,
-            inline: true,
-          },
-          {
-            name: '💰 Balance After',
-            value: `${balanceAfter.toLocaleString()} coins`,
-            inline: true,
-          },
+          { name: '🕒 Duration Removed', value: `${minutes} minutes`, inline: true },
+          { name: '📅 Date (UTC)', value: dateInput, inline: true },
+          { name: '💰 Coins Deducted', value: `-${coinsDelta.toLocaleString()}`, inline: true },
+          { name: '💵 Balance Before', value: `${balanceBefore.toLocaleString()} coins`, inline: true },
+          { name: '💰 Balance After', value: `${balanceAfter.toLocaleString()} coins`, inline: true },
         )
         .setFooter({ text: `Staff: ${interaction.user.username}` })
         .setTimestamp();
 
       await interaction.editReply({ embeds: [embed] });
 
-      // Send audit log to configured channel (if available)
       await sendAuditLog(interaction, {
-        type: 'add',
+        type: 'remove',
         targetUserId: targetUser.id,
         targetUsername: targetUser.username,
         minutes,
-        coinsDelta: coinsEarned,
+        coinsDelta: -coinsDelta,
         balanceBefore,
         balanceAfter,
         dateInput,
       });
 
       logger.info(
-        `Staff ${interaction.user.id} manually added ${minutes} minutes (${durationMs} ms) of VC time ` +
-        `to user ${targetUser.id} in guild ${guildId}, coinsEarned=${coinsEarned}, ` +
+        `Staff ${interaction.user.id} manually removed ${minutes} minutes (${durationMs} ms) of VC time ` +
+        `from user ${targetUser.id} in guild ${guildId}, coinsRemoved=${coinsDelta}, ` +
         `balance: ${balanceBefore} -> ${balanceAfter}`
       );
     } catch (error) {
-      logger.error('Error in add-hours command:', error);
+      logger.error('Error in remove-hours command:', error);
       if (interaction.deferred || interaction.replied) {
         await interaction.editReply({
-          content: '❌ An unexpected error occurred while adding hours.',
+          content: '❌ An unexpected error occurred while removing hours.',
         });
       } else {
         await interaction.reply({
-          content: '❌ An unexpected error occurred while adding hours.',
+          content: '❌ An unexpected error occurred while removing hours.',
           ephemeral: true,
         });
       }
@@ -230,7 +203,7 @@ export default {
 async function sendAuditLog(
   interaction: ChatInputCommandInteraction,
   data: {
-    type: 'add';
+    type: 'remove';
     targetUserId: string;
     targetUsername: string;
     minutes: number;
@@ -249,12 +222,12 @@ async function sendAuditLog(
     if (!channel || !channel.isTextBased()) return;
 
     const embed = new EmbedBuilder()
-      .setColor(0x2ecc71)
-      .setTitle('Staff Manual Hours Added')
+      .setColor(0xe67e22)
+      .setTitle('Staff Manual Hours Removed')
       .setDescription(`<@${data.targetUserId}> (${data.targetUsername})`)
       .addFields(
-        { name: 'Minutes Added', value: `${data.minutes}`, inline: true },
-        { name: 'Coins Delta', value: `+${data.coinsDelta.toLocaleString()}`, inline: true },
+        { name: 'Minutes Removed', value: `${data.minutes}`, inline: true },
+        { name: 'Coins Delta', value: `${data.coinsDelta.toLocaleString()}`, inline: true },
         { name: 'Date (UTC)', value: data.dateInput, inline: true },
         { name: 'Balance Before', value: data.balanceBefore.toLocaleString(), inline: true },
         { name: 'Balance After', value: data.balanceAfter.toLocaleString(), inline: true },
@@ -264,6 +237,6 @@ async function sendAuditLog(
 
     await (channel as any).send({ embeds: [embed] });
   } catch (error) {
-    logger.warn('Failed to send audit log for add-hours:', error);
+    logger.warn('Failed to send audit log for remove-hours:', error);
   }
 }

--- a/src/commands/removeHours.ts
+++ b/src/commands/removeHours.ts
@@ -34,15 +34,7 @@ export default {
 
   async execute(interaction: ChatInputCommandInteraction) {
     try {
-      const guildId = interaction.guildId;
-      if (!guildId) {
-        await interaction.reply({
-          content: '❌ This command can only be used in a server.',
-          ephemeral: true,
-        });
-        return;
-      }
-
+      const guildId = interaction.guildId!;
       const member = interaction.member;
 
       if (!member || typeof (member as any).permissions === 'string') {
@@ -127,11 +119,14 @@ export default {
         }
       );
 
-      if (updateResult.modifiedCount === 0) {
+      if (updateResult.matchedCount === 0) {
+        logger.warn(
+          `remove-hours: update matched 0 documents for user ${targetUser.id} in guild ${guildId}`
+        );
         await interaction.editReply({
-          content: '❌ Failed to update user record. No changes were made.',
+          content: '⚠️ User record was not found while applying the update, but continuing. Please verify the result.',
         });
-        return;
+        // Continue to create transaction/audit so staff can see what was attempted
       }
 
       const transactionId = `tx_manual_remove_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;


### PR DESCRIPTION
- Added functionality to send an audit log to a configured channel when staff manually add hours to a user's account.
- Introduced a new `sendAuditLog` function to format and send the log message, including details such as target user, minutes added, coins delta, and balance changes.
- Enhanced logging for better tracking of manual hour additions by staff members.