### PR TITLE
fix: added a check to exclude disbanded factions from faction rankings

### DIFF
--- a/src/commands/eventFaction.ts
+++ b/src/commands/eventFaction.ts
@@ -401,6 +401,7 @@ async function handleDisbandFaction(
     { id: faction.id, guildId },
     {
       $set: {
+        name: `${faction.name}-disbanded-${Date.now()}`,
         disbanded: true,
         disbandedAt: new Date(),
         disbandedReason: 'manual',

--- a/src/modules/factions/services/disbandManager.ts
+++ b/src/modules/factions/services/disbandManager.ts
@@ -59,6 +59,7 @@ export class DisbandManager {
         { id: factionId, guildId },
         {
           $set: {
+            name: `${faction.name}-disbanded-${Date.now()}`,
             disbanded: true,
             disbandedAt: new Date(),
             disbandedReason: reason,

--- a/src/modules/leaderboard/services/leaderboardService.ts
+++ b/src/modules/leaderboard/services/leaderboardService.ts
@@ -194,7 +194,11 @@ export class LeaderboardService {
 
       // Query factions sorted by treasury
       const factions = await database.factions
-        .find({ guildId, treasury: { $gt: 0 } })
+        .find({ 
+          guildId, 
+          treasury: { $gt: 0 },
+          disbanded: { $ne: true } 
+         })
         .sort({ treasury: -1 })
         .limit(this.LEADERBOARD_LIMIT)
         .toArray();


### PR DESCRIPTION
fixes #14 Disbanded factions appear in /faction-rankings