### PR TITLE
feat: Add event faction rankings functionality to leaderboard service

### DIFF
--- a/src/commands/eventLeaderboard.ts
+++ b/src/commands/eventLeaderboard.ts
@@ -1,0 +1,109 @@
+import { SlashCommandBuilder, ChatInputCommandInteraction, EmbedBuilder } from 'discord.js';
+import { leaderboardService } from '../modules/leaderboard/services/leaderboardService';
+import logger from '../core/logger';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('event-leaderboard')
+    .setDescription('View event factions ranked by treasury'),
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    try {
+      await interaction.deferReply();
+
+      const guildId = interaction.guildId!;
+
+      const result = await leaderboardService.getEventFactionRankings(guildId);
+
+      if (result.entries.length === 0) {
+        await interaction.editReply({
+          embeds: [
+            createErrorEmbed(
+              'No Event Factions',
+              'There are no event factions on this server yet.'
+            ),
+          ],
+        });
+        return;
+      }
+
+      const topFaction = result.entries[0];
+      let top3Members: { username: string; value: number; rank: number }[] = [];
+
+      const memberResult = await leaderboardService.getFactionMemberLeaderboard(
+        guildId,
+        topFaction.factionId,
+        'deposits'
+      );
+      top3Members = memberResult.entries.slice(0, 3).map((e) => ({
+        username: e.username,
+        value: e.value,
+        rank: e.rank,
+      }));
+
+      // Spotlight: top faction + its top 3 by deposits
+      let spotlight = `**#1 — ${topFaction.factionName}**\n`;
+      spotlight += `💰 Treasury: **${topFaction.treasury.toLocaleString()}** coins\n`;
+      if (top3Members.length > 0) {
+        spotlight += `**Top 3 contributors:**\n`;
+        for (const m of top3Members) {
+          spotlight += `${m.rank}. ${m.username} — **${m.value.toLocaleString()}** deposited\n`;
+        }
+      } else {
+        spotlight += `*No member deposits yet.*\n`;
+      }
+
+      // Full event faction list
+      let fullList = `\n**All event factions**\n`;
+      for (const entry of result.entries) {
+        const medal = this.getMedal(entry.rank);
+        fullList += `${medal} **${entry.rank}.** ${entry.factionName} — **${entry.treasury.toLocaleString()}** coins\n`;
+      }
+
+      const description = spotlight + fullList;
+
+      const embed = new EmbedBuilder()
+        .setColor(0xf39c12)
+        .setTitle('Event Factions Leaderboard')
+        .setDescription(description)
+        .setFooter({
+          text: result.fromCache
+            ? 'Data cached - Updates every 15 minutes'
+            : 'Fresh data calculated',
+        })
+        .setTimestamp();
+
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      logger.error('Error in event-leaderboard command:', error);
+      await interaction.editReply({
+        embeds: [
+          createErrorEmbed(
+            'Error',
+            'An unexpected error occurred while fetching the event leaderboard.'
+          ),
+        ],
+      });
+    }
+  },
+
+  getMedal(rank: number): string {
+    switch (rank) {
+      case 1:
+        return '🥇';
+      case 2:
+        return '🥈';
+      case 3:
+        return '🥉';
+      default:
+        return '📊';
+    }
+  },
+};
+
+function createErrorEmbed(title: string, description: string): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle(`❌ ${title}`)
+    .setDescription(description)
+    .setColor(0xe74c3c);
+}

--- a/src/commands/eventLeaderboard.ts
+++ b/src/commands/eventLeaderboard.ts
@@ -5,13 +5,22 @@ import logger from '../core/logger';
 export default {
   data: new SlashCommandBuilder()
     .setName('event-leaderboard')
-    .setDescription('View event factions ranked by treasury'),
+    .setDescription('View event factions ranked by treasury')
+    .setDMPermission(false),
 
   async execute(interaction: ChatInputCommandInteraction) {
     try {
+      if (!interaction.guildId || !interaction.inGuild()) {
+        await interaction.reply({
+          content: 'This command can only be used in a server.',
+          ephemeral: true,
+        });
+        return;
+      }
+
       await interaction.deferReply();
 
-      const guildId = interaction.guildId!;
+      const guildId = interaction.guildId;
 
       const result = await leaderboardService.getEventFactionRankings(guildId);
 

--- a/src/modules/leaderboard/services/cacheService.ts
+++ b/src/modules/leaderboard/services/cacheService.ts
@@ -187,6 +187,13 @@ export class CacheService {
   buildFactionRankingsKey(guildId: string): string {
     return `leaderboard:${guildId}:faction_rankings:treasury`;
   }
+
+  /**
+   * Build cache key for event faction rankings
+   */
+  buildEventFactionRankingsKey(guildId: string): string {
+    return `leaderboard:${guildId}:event_faction_rankings:treasury`;
+  }
 }
 
 export const cacheService = new CacheService();

--- a/src/modules/leaderboard/services/leaderboardService.ts
+++ b/src/modules/leaderboard/services/leaderboardService.ts
@@ -16,6 +16,7 @@ import logger from '../../../core/logger';
  */
 export class LeaderboardService {
   private readonly LEADERBOARD_LIMIT = 10;
+  private readonly EVENT_FACTION_RANKINGS_LIMIT = 15;
 
   /**
    * Get personal leaderboard (coins, vctime, or streak)
@@ -69,6 +70,26 @@ export class LeaderboardService {
     const { data, fromCache } = await cacheService.getOrCalculate(
       cacheKey,
       () => this.calculateFactionRankings(guildId)
+    );
+
+    return {
+      entries: data,
+      total: data.length,
+      fromCache,
+    };
+  }
+
+  /**
+   * Get event faction rankings (event factions only, treasury-based)
+   */
+  async getEventFactionRankings(
+    guildId: string
+  ): Promise<LeaderboardResult<FactionLeaderboardEntry>> {
+    const cacheKey = cacheService.buildEventFactionRankingsKey(guildId);
+
+    const { data, fromCache } = await cacheService.getOrCalculate(
+      cacheKey,
+      () => this.calculateEventFactionRankings(guildId)
     );
 
     return {
@@ -211,6 +232,41 @@ export class LeaderboardService {
       return entries;
     } catch (error) {
       logger.error('Error calculating faction rankings:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Calculate event faction rankings from database (event factions only, treasury-based)
+   */
+  private async calculateEventFactionRankings(
+    guildId: string
+  ): Promise<FactionLeaderboardEntry[]> {
+    try {
+      logger.info(`Calculating event faction rankings for guild ${guildId}`);
+
+      const factions = await database.factions
+        .find({
+          guildId,
+          ownerId: 'EVENTFACTION',
+          disbanded: { $ne: true },
+          treasury: { $gte: 0 },
+        })
+        .sort({ treasury: -1 })
+        .limit(this.EVENT_FACTION_RANKINGS_LIMIT)
+        .toArray();
+
+      const entries: FactionLeaderboardEntry[] = factions.map((faction, index) => ({
+        factionId: faction.id,
+        factionName: faction.name,
+        treasury: faction.treasury,
+        rank: index + 1,
+      }));
+
+      logger.info(`Calculated ${entries.length} entries for event faction rankings`);
+      return entries;
+    } catch (error) {
+      logger.error('Error calculating event faction rankings:', error);
       return [];
     }
   }


### PR DESCRIPTION
- Introduced a new method `getEventFactionRankings` to retrieve event faction rankings from the cache.
- Added a private method `calculateEventFactionRankings` to compute rankings based on treasury values.
- Created a new cache key method `buildEventFactionRankingsKey` in the CacheService for event faction rankings.